### PR TITLE
Simplify reusable workflow

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -11,10 +11,6 @@ on:
             - main
             - dev
     workflow_call:
-        secrets:
-            GITHUB_TOKEN:
-                description: GitHub token passed from the caller workflow
-                required: true
 
 jobs:
     lint:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -28,7 +28,7 @@ jobs:
               uses: github/super-linter@v4
               env:
                   DEFAULT_BRANCH: main
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ github.token }}
                   JAVASCRIPT_DEFAULT_STYLE: prettier
                   MARKDOWN_CONFIG_FILE: .markdownlint.yaml
                   VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
`github` context is provided by default, so it's redundant to pass it in.